### PR TITLE
Sync dropdown with onItemsPerPageSelect

### DIFF
--- a/src/TablePresentation.jsx
+++ b/src/TablePresentation.jsx
@@ -81,7 +81,7 @@ class TablePresentation extends React.Component {
     render() {
         let filters = this.filters(),
             {pageCount, activePage, onPageSelect, searchText, sortColumn, sortOrder, onSort, visibleRows,
-            selectedRows} = this.props,
+            selectedRows, itemsPerPage} = this.props,
             columns = React.Children.toArray(this.props.children);
 
         return (
@@ -89,9 +89,12 @@ class TablePresentation extends React.Component {
                 <Row>
                     <Col md={6}>
                         Show{' '}
-                        <FormControl componentClass="select" placeholder="select" defaultValue="25"
-                                     className="input-sm select-entry-count"
-                                     onChange={this.onItemsPerPageSelect.bind(this)}>
+                        <FormControl
+                            className="input-sm select-entry-count"
+                            componentClass="select"
+                            onChange={this.onItemsPerPageSelect.bind(this)}
+                            placeholder="select"
+                            value={itemsPerPage}>
                             <option value="10">10</option>
                             <option value="25">25</option>
                             <option value="50">50</option>
@@ -103,7 +106,6 @@ class TablePresentation extends React.Component {
                         <div className="pull-right">
                             Search:{' '}
                             <FormControl
-
                                 type="text"
                                 value={searchText}
                                 placeholder=""
@@ -157,7 +159,5 @@ class TablePresentation extends React.Component {
         );
     }
 }
-
-
 
 export default TablePresentation;


### PR DESCRIPTION
Fix #10.

![testresult](https://cloud.githubusercontent.com/assets/10692276/23263529/77e80e18-fa19-11e6-98ff-5a189d5f9e48.gif)

No worry about change the `defaultValue` to `value` will lock the value forever, since `event` below will bring the new value and make `itemsPerPage` from state the single source of truth for the dropdown value 😀
```
onItemsPerPageSelect(event) {
    this.props.onItemsPerPageSelect(parseInt(event.target.value));
}
```